### PR TITLE
Fix for multiple captions not working

### DIFF
--- a/demo/module/App.ts
+++ b/demo/module/App.ts
@@ -16,6 +16,7 @@ const player = PlayerFactory.get(playerContainer, {
       'volume',
       'captions',
       'fullscreen',
+      'settings',
     ],
     addons: {
       seekPreview: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "mini-css-extract-plugin": "^1.4.1",
         "prettier": "^2.3.2",
         "prettier-package-json": "^2.1.3",
+        "source-map-loader": "^3.0.0",
         "stylelint": "^13.13.1",
         "stylelint-config-recommended": "^5.0.0",
         "stylelint-config-standard": "^22.0.0",
@@ -12084,6 +12085,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-loader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.0.tgz",
+      "integrity": "sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.2",
+        "source-map-js": "^0.6.2"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/source-map-loader/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
@@ -23971,6 +24005,28 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "dev": true
+    },
+    "source-map-loader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.0.tgz",
+      "integrity": "sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.2",
+        "source-map-js": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
     },
     "source-map-support": {
       "version": "0.5.12",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "mini-css-extract-plugin": "^1.4.1",
     "prettier": "^2.3.2",
     "prettier-package-json": "^2.1.3",
+    "source-map-loader": "^3.0.0",
     "stylelint": "^13.13.1",
     "stylelint-config-recommended": "^5.0.0",
     "stylelint-config-standard": "^22.0.0",

--- a/src/MediaPlayer/Plyr/PlyrWrapper.test.ts
+++ b/src/MediaPlayer/Plyr/PlyrWrapper.test.ts
@@ -496,6 +496,19 @@ describe('Playback restriction', () => {
         },
       );
     });
+
+    it('updates the streaming captions when the captions are changed', () => {
+      const segment = {
+        end: 60,
+      };
+      setupMockPlayer();
+      mediaPlayer.configureWithVideo(video, segment);
+      mockPlyr.currentTrack = 0;
+
+      mockPlyr.__callEventCallback('languagechange');
+
+      expect(mockStreamingTechnique.changeCaptions).toHaveBeenCalledWith(0);
+    });
   });
 
   describe('Fullscreen', () => {

--- a/src/MediaPlayer/Plyr/PlyrWrapper.ts
+++ b/src/MediaPlayer/Plyr/PlyrWrapper.ts
@@ -226,6 +226,11 @@ export default class PlyrWrapper implements MediaPlayer {
     };
 
     this.plyr.on('languagechange', forceShowCaption);
+    this.plyr.on('languagechange', (e) => {
+      if (this.streamingTechnique) {
+        this.streamingTechnique.changeCaptions(e.detail.plyr.currentTrack);
+      }
+    });
 
     if (this.onEndCallback) {
       this.plyr.on('ended', () => {

--- a/src/StreamingTechnique/HlsWrapper/HlsWrapper.ts
+++ b/src/StreamingTechnique/HlsWrapper/HlsWrapper.ts
@@ -18,6 +18,14 @@ export class HlsWrapper implements StreamingTechnique {
     private readonly logger: Logger = new NullLogger(),
   ) {}
 
+  public changeCaptions = (trackNumber: number) => {
+    if (!this.canCallHls()) {
+      return;
+    }
+
+    this.hls.subtitleTrack = trackNumber;
+  };
+
   public initialise = (
     playback: StreamPlayback,
     startPosition: number = -1,

--- a/src/StreamingTechnique/StreamingTechnique.ts
+++ b/src/StreamingTechnique/StreamingTechnique.ts
@@ -5,4 +5,5 @@ export interface StreamingTechnique {
   destroy: () => void;
   startLoad: (startTime: number) => void;
   stopLoad: () => void;
+  changeCaptions: (trackNumber: number) => void;
 }

--- a/src/StreamingTechnique/__mocks__/StreamingTechniqueFactory.ts
+++ b/src/StreamingTechnique/__mocks__/StreamingTechniqueFactory.ts
@@ -5,6 +5,7 @@ export const MockStreamingTechnique: StreamingTechnique = {
   startLoad: jest.fn(),
   stopLoad: jest.fn(),
   destroy: jest.fn(),
+  changeCaptions: jest.fn(),
 };
 
 // noinspection JSUnusedGlobalSymbols

--- a/webpack-config/webpack.dev.js
+++ b/webpack-config/webpack.dev.js
@@ -11,5 +11,14 @@ module.exports = merge(common, {
     port: 8081,
     static: distPath,
   },
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        enforce: 'pre',
+        use: ['source-map-loader'],
+      },
+    ],
+  },
 });


### PR DESCRIPTION
@remo1 said his fix wasn't working for @rlewan, so it would be good to get someone else to test this.

The basic premise here is to let the hls library know every time the user changes caption language, so it can do its magic with loading captions. 

To test you'll need to change loadVideo argument in `demo/module/App.ts` to that of the video in the [story](https://www.pivotaltracker.com/n/projects/2410469/stories/179217614). Then you can `npm run demo:module` and head over to http://localhost:8081
